### PR TITLE
Limit field mapping to fields of the same type as the property

### DIFF
--- a/PropertyChanging.Fody/MappingFinder.cs
+++ b/PropertyChanging.Fody/MappingFinder.cs
@@ -31,7 +31,7 @@ public partial class ModuleWeaver
     static FieldDefinition TryGetField(TypeDefinition typeDefinition, PropertyDefinition property)
     {
         var propertyName = property.Name;
-        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition).ToList();
+        var fieldsWithSameType = typeDefinition.Fields.Where(x => x.DeclaringType == typeDefinition && x.FieldType == property.PropertyType).ToList();
         foreach (var field in fieldsWithSameType)
         {
             //AutoProp

--- a/TestAssemblies/AssemblyToProcess/ClassWithNullableBackingField.cs
+++ b/TestAssemblies/AssemblyToProcess/ClassWithNullableBackingField.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+
+public class ClassWithNullableBackingField : INotifyPropertyChanging
+{
+    // Issue 156
+
+    bool? _isFlag;
+
+    public bool IsFlag
+    {
+        get => _isFlag ?? (_isFlag = GetFlag()).Value;
+        set => _isFlag = value;
+    }
+
+    bool GetFlag() => false;
+
+    public event PropertyChangingEventHandler PropertyChanging;
+}

--- a/Tests/BaseTaskTests.cs
+++ b/Tests/BaseTaskTests.cs
@@ -943,6 +943,26 @@ public class WeavingTaskTests :
         Assert.False(property1EventCalled);
     }
 
+    [Fact]
+    public void ClassWithNullableBackingField()
+    {
+        var instance = testResult.GetInstance("ClassWithNullableBackingField");
+        var isFlagEventCalled = false;
+        ((INotifyPropertyChanging)instance).PropertyChanging += (sender, args) =>
+        {
+            if (args.PropertyName == "IsFlag")
+            {
+                isFlagEventCalled = true;
+            }
+        };
+        instance.IsFlag = true;
+        Assert.True(isFlagEventCalled);
+
+        isFlagEventCalled = false;
+        instance.IsFlag = true;
+        Assert.False(isFlagEventCalled);
+    }
+
     public WeavingTaskTests(ITestOutputHelper output) :
         base(output)
     {


### PR DESCRIPTION
Fixes #156 by ensuring that fields are mapped to properties only if they are of the same type.